### PR TITLE
examples/index.html 的第105行 succFunc参数无效，修改为 successFunc。

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -102,7 +102,7 @@
 					<td>#000</td>
 				</tr>
 				<tr>
-					<td>succFunc</td>
+					<td>successFunc</td>
 					<td>callback function when success</td>
 					<td><code>function() { alert(&#39;successfully
 							unlock!&#39;); }</code></td>


### PR DESCRIPTION
根据unlock.js 里面的参数，succFunc实际上是successFunc才是正确的。